### PR TITLE
provide better .Right indicator placement

### DIFF
--- a/RNLoadingButton/RNLoadingButton.swift
+++ b/RNLoadingButton/RNLoadingButton.swift
@@ -368,9 +368,14 @@ public class RNLoadingButton: UIButton {
             }
             else if ( Float(x + Float(frame.size.width) ) > Float(self.frame.size.width - self.activityIndicatorEdgeInsets.right)){
                 x = Float(self.frame.size.width) - ( Float(frame.size.width) + Float(self.activityIndicatorEdgeInsets.right) );
+            } else {
+                // default to placing the indicator at 3/4 the buttons length, making sure it doesn't touch the button content
+                let contentRightEdge = (lengthOccupied / 2) + (Float(frame.width) / 2)
+                let threeFourthsButtonWidth = 3 * (Float(frame.width) / 4)
+                x = max(contentRightEdge, threeFourthsButtonWidth)
             }
 
-            frame.origin.x = CGFloat(x);
+            frame.origin.x = CGFloat(x)
         }
         
         return frame;


### PR DESCRIPTION
Thought this was a better default for the .Right indicator alignment, it made it so (in my case) I didn't need custom insets.

100% open to discussion on this - I'd really like to use and make this library better rather than implement my own loading button!

Thank you for all of your work 😄 
